### PR TITLE
[s2i-yarn-static] Add possibility to provide configuration template

### DIFF
--- a/s2i/yarn-static/Dockerfile
+++ b/s2i/yarn-static/Dockerfile
@@ -21,7 +21,8 @@ LABEL io.k8s.description="Platform for building static webpages based on yarn" \
 RUN curl -sL https://dl.yarnpkg.com/rpm/yarn.repo > /etc/yum.repos.d/yarn.repo && \
         curl -sL https://rpm.nodesource.com/setup_8.x | bash - && \
         yum install -y epel-release
-RUN yum install -y nginx-${NGINX_VERSION} nodejs-${NODE_VERSION} yarn-${YARN_VERSION} && \
+RUN yum install -y nginx-${NGINX_VERSION} nodejs-${NODE_VERSION} yarn-${YARN_VERSION} python-pip && \
+        pip install envtpl && \
         yum clean all && \
         chown -R 1001:1001 /var/log/nginx && \
         chmod g+rw /var/run && \

--- a/s2i/yarn-static/s2i/bin/assemble
+++ b/s2i/yarn-static/s2i/bin/assemble
@@ -14,8 +14,14 @@ fi
 
 echo "---> Building application from source..."
 pushd /tmp/src > /dev/null
+
 yarn
 yarn build
 mv build/* /opt/app-root
+
+if [ -e "config.json.tpl" ]; then
+	cp config.json.tpl /opt/app-root
+fi
+
 popd > /dev/null
 rm -rf /tmp/src

--- a/s2i/yarn-static/s2i/bin/run
+++ b/s2i/yarn-static/s2i/bin/run
@@ -6,5 +6,10 @@
 # For more information see the documentation:
 #	https://github.com/openshift/source-to-image/blob/master/docs/builder_image.md
 #
+CONFIGURATION_TEMPLATE="/opt/app-root/config.json.tpl"
+
+if [ -e  "$CONFIGURATION_TEMPLATE" ]; then
+    envtpl "$CONFIGURATION_TEMPLATE"
+fi
 
 exec nginx


### PR DESCRIPTION
This allows providing a `config.json.tpl` in the source root which will be filled using `envtpl` and exposed using at the `/config.json` path.