### PR TITLE
Make 's2i-yarn-static' able to handle single page applications

### DIFF
--- a/s2i/yarn-static/Dockerfile
+++ b/s2i/yarn-static/Dockerfile
@@ -29,8 +29,9 @@ RUN yum install -y nginx-${NGINX_VERSION} nodejs-${NODE_VERSION} yarn-${YARN_VER
         chmod g+rw /var/run /opt/app-root && \
         yarn --version && \
         node --version
-COPY default.conf /etc/nginx/conf.d/default.conf
+COPY default.conf.tpl /etc/nginx/conf.d/default.conf.tpl
 COPY nginx.conf /etc/nginx/nginx.conf
+RUN chmod -R a+w /etc/nginx/conf.d
 
 # --------------------
 # BUILD LOGIC

--- a/s2i/yarn-static/default.conf
+++ b/s2i/yarn-static/default.conf
@@ -1,7 +1,0 @@
-server {
-    listen 8080;
-
-    location / {
-        root /opt/app-root;
-    }
-}

--- a/s2i/yarn-static/default.conf.tpl
+++ b/s2i/yarn-static/default.conf.tpl
@@ -1,0 +1,10 @@
+server {
+    listen 8080;
+
+    location / {
+        root /opt/app-root;
+        {% if NGINX_NO_INDEX_FALLBACK is not defined %}
+        try_files $uri /index.html;
+        {% endif %}
+    }
+}

--- a/s2i/yarn-static/s2i/bin/run
+++ b/s2i/yarn-static/s2i/bin/run
@@ -9,8 +9,15 @@
 CONFIGURATION_TEMPLATE="/opt/app-root/config.json.tpl"
 
 if [ -e  "$CONFIGURATION_TEMPLATE" ]; then
-    echo "---> Creating configuration from template..."
+    echo "---> Creating JSON configuration from template..."
     envtpl "$CONFIGURATION_TEMPLATE"
+    cat "/opt/app-root/config.json"
+    echo
 fi
+
+echo "---> Creating nginx configuration ..."
+envtpl "/etc/nginx/conf.d/default.conf.tpl"
+cat "/etc/nginx/conf.d/default.conf"
+echo
 
 exec nginx


### PR DESCRIPTION
This will always route to `index.html` instead of returning a 404 response _unless_ the `NGINX_NO_INDEX_FALLBACK` environment variable is set.